### PR TITLE
Use pg_get_expr to pass testing

### DIFF
--- a/sql.go
+++ b/sql.go
@@ -13,7 +13,7 @@ SELECT
          SELECT 1 FROM pg_attrdef ad
          WHERE  ad.adrelid = a.attrelid
          AND    ad.adnum   = a.attnum
-         AND    ad.adbin   = 'nextval('''
+         AND    pg_get_expr(ad.adbin, ad.adrelid) = 'nextval('''
             || (pg_get_serial_sequence (a.attrelid::regclass::text
                                       , a.attname))::regclass
             || '''::regclass)'


### PR DESCRIPTION
`go test` fails at `TestLoadColumnDef` in master branch. This pull request will fix it. 

```
--- FAIL: TestLoadColumnDef (0.05s)
    planter_test.go:101:
        &{FieldOrdinal:1 Name:id Comment:{String: Valid:false} DataType:bigint DDLType:bigint NotNull:true IsPrimaryKey:true IsForeignKey:false}
        &{FieldOrdinal:1 Name:id Comment:{String: Valid:false} DataType:bigint DDLType:bigserial NotNull:true IsPrimaryKey:true IsForeignKey:false}
FAIL
exit status 1
FAIL    github.com/achiku/planter       0.686s
```

You know `pg_attrdef.adsrc` was removed in Postgres v12 so `adsrc` was replaces with `adbin` in commit 575e277b09ac3d68daa5c7b3a5c44041689eeedf. However, `adbin` is not a human readable string type such as `nextval('xxx_id_seq'::regclass)`, the SQL condition like `ad.adbin   = 'nextval('''` doesn't work properly. `pg_get_expr(adbin, adrelid)` will resolve this problem.

Ref: https://www.postgresql.org/docs/12/catalog-pg-attrdef.html