### PR TITLE
Show `serial` instead of `int` if the column is associated with the sequence

### DIFF
--- a/sql.go
+++ b/sql.go
@@ -13,7 +13,7 @@ SELECT
          SELECT 1 FROM pg_attrdef ad
          WHERE  ad.adrelid = a.attrelid
          AND    ad.adnum   = a.attnum
-         AND    ad.adbin   = 'nextval('''
+         AND    pg_get_expr(ad.adbin, ad.adrelid) = 'nextval('''
             || (pg_get_serial_sequence (a.attrelid::regclass::text
                                       , a.attname))::regclass
             || '''::regclass)'

--- a/template.go
+++ b/template.go
@@ -8,13 +8,13 @@ entity "{{ .Name }}" {
 {{- end }}
 {{- range .Columns }}
   {{- if .IsPrimaryKey }}
-  + {{ .Name }}:{{ .DataType }} [PK]{{if .IsForeignKey }}[FK]{{end}}{{- if .Comment.Valid }} : {{ .Comment.String }}{{- end }}
+  + {{ .Name }}:{{ .DDLType }} [PK]{{if .IsForeignKey }}[FK]{{end}}{{- if .Comment.Valid }} : {{ .Comment.String }}{{- end }}
   {{- end }}
 {{- end }}
   --
 {{- range .Columns }}
   {{- if not .IsPrimaryKey }}
-  {{if .NotNull}}*{{end}}{{ .Name }}:{{ .DataType }} {{if .IsForeignKey}}[FK]{{end}} {{- if .Comment.Valid }} : {{ .Comment.String }}{{- end }}
+  {{if .NotNull}}*{{end}}{{ .Name }}:{{ .DDLType }} {{if .IsForeignKey}}[FK]{{end}} {{- if .Comment.Valid }} : {{ .Comment.String }}{{- end }}
   {{- end }}
 {{- end }}
 }


### PR DESCRIPTION
`planter` generates a UML like following.

```
@startuml
hide circle
skinparam linetype ortho

entity "bar" {
  + foo_id:bigint [PK][FK]
  --
  *bar_id:bigint
}

entity "foo" {
  + id:bigint [PK]
  --
  *name:text
  *created_at:timestamp with time zone
}

 bar ||-|| foo
@enduml
```

This pull request will show `serial` type if the column is associated with the sequence. Look at `foo.id` column.

```
@startuml
hide circle
skinparam linetype ortho

entity "bar" {
  + foo_id:bigint [PK][FK]
  --
  *bar_id:bigint
}

entity "foo" {
  + id:bigserial [PK]
  --
  *name:text
  *created_at:timestamp with time zone
}

 bar ||-|| foo
@enduml
```

# Table definition

```
create table foo (id bigserial primary key, name text not null, created_at timestamp with time zone not null);
create table bar (foo_id bigint primary key, bar_id bigint not null, foreign key(foo_id) references foo (id));
```

```
   Column   |           Type           | Collation | Nullable |             Default
------------+--------------------------+-----------+----------+---------------------------------
 id         | bigint                   |           | not null | nextval('foo_id_seq'::regclass)
 name       | text                     |           | not null |
 created_at | timestamp with time zone |           | not null |
Indexes:
    "foo_pkey" PRIMARY KEY, btree (id)
Referenced by:
    TABLE "bar" CONSTRAINT "bar_foo_id_fkey" FOREIGN KEY (foo_id) REFERENCES foo(id)
```

```
 Column |  Type  | Collation | Nullable | Default
--------+--------+-----------+----------+---------
 foo_id | bigint |           | not null |
 bar_id | bigint |           | not null |
Indexes:
    "bar_pkey" PRIMARY KEY, btree (foo_id)
Foreign-key constraints:
    "bar_foo_id_fkey" FOREIGN KEY (foo_id) REFERENCES foo(id)
```


