### PR TITLE
Support PostgreSQL 10+ partitioning

### DIFF
--- a/sql.go
+++ b/sql.go
@@ -48,7 +48,7 @@ JOIN ONLY pg_namespace n
 ON n.oid = c.relnamespace
 LEFT JOIN pg_description pd ON pd.objoid = c.oid AND pd.objsubid = 0
 WHERE n.nspname = $1
-AND c.relkind = 'r'
+AND c.relkind in ('r','p') AND NOT COALESCE((row_to_json(c)->>'relispartition')::boolean,false)
 ORDER BY c.relname
 `
 
@@ -79,6 +79,7 @@ from (
   where ns.nspname = $1
   and cl.relname = $2
   and con1.contype = 'f'
+  and (coalesce((row_to_json(con1)->>'conparentid'),'0')::oid) = 0
 ) con
 join pg_attribute att
 on att.attrelid = con.confrelid and att.attnum = con.child


### PR DESCRIPTION
Include partitioned tables, but ignore their partitions. Without this change, it would fail on database schemas involving partitioning.

Note the use of the `row_to_json()` function is to permit backward compatibility with PostgreSQL 9 and 10. The `relispartition` column does not exist until PostgreSQL 10 and the `conparentid` column does not exist until PostgreSQL 11. Directly referencing these columns, while simpler, would cause the query to fail in those earlier versions. While another approach would be to generate different SQL for different PostgreSQL versions, that seems like it would be more work. Note however that this use of JSON means it will no longer work on PostgreSQL 9.2 and earlier, since the necessary JSON support was introduced in 9.3. That's hopefully not a big issue, given 9.2 reached its end-of-support date almost 5 years ago.