### PR TITLE
Support Go 1.19, 1.18 and 1.17

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,9 +16,9 @@ jobs:
             # - macOS-latest
             # - windows-latest
         go:
-          - "1.16"
-          - "1.15"
-          - "1.14"
+          - "1.19"
+          - "1.18"
+          - "1.17"
     services:
       postgres:
         image: postgres:12

--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,14 @@
 module github.com/achiku/planter
 
-go 1.16
+go 1.19
 
 require (
 	github.com/alecthomas/kingpin v2.2.6+incompatible
-	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 // indirect
-	github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d // indirect
 	github.com/lib/pq v1.2.0
 	github.com/pkg/errors v0.8.1
+)
+
+require (
+	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 // indirect
+	github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d // indirect
 )


### PR DESCRIPTION
A simple PR. Update Go version to the latest and run test with Go 1.19, 1.18 and 1.17.