### PR TITLE
Seems go changed how you install programs

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ A team with only software engineers doesn't need ER diagram that much as long as
 ## Installation
 
 ```
-go get -u github.com/achiku/planter
+go install github.com/achiku/planter@latest
 ```
 
 ## Quick Start


### PR DESCRIPTION
I was getting this;

```
$ go get -u github.com/achiku/planter
go: go.mod file not found in current directory or any parent directory.
	'go get' is no longer supported outside a module.
	To build and install a command, use 'go install' with a version,
	like 'go install example.com/cmd@latest'
	For more information, see https://golang.org/doc/go-get-install-deprecation
	or run 'go help get' or 'go help install'
```